### PR TITLE
fix: pause erroring

### DIFF
--- a/src/Implementation/Timer.ts
+++ b/src/Implementation/Timer.ts
@@ -100,7 +100,7 @@ export class Timer implements ITimer {
 	}
 
 	public pause(): void {
-		if (this.state === TimerState.Running) {
+		if (this.state !== TimerState.Running) {
 			throw "Cannot pause a timer that is not running";
 		}
 


### PR DESCRIPTION
Right now, the `pause` method will cause the timer to error if it's running, which is not intentional. This fixes the bug.